### PR TITLE
Add #include <string> to example

### DIFF
--- a/chapters/cplusplus_basics/unabridged.md
+++ b/chapters/cplusplus_basics/unabridged.md
@@ -236,6 +236,7 @@ We will now define our own function and make use of it as a word template. Type 
 
 ```cpp
 #include <iostream>
+#include <string>
 using namespace std;
 
 void greet(string person){


### PR DESCRIPTION
In visual studio, without #include <string> . The example cout << "Hi there " << person << "." << endl; will not work.